### PR TITLE
odroid-c1: fix machine rrecommends

### DIFF
--- a/conf/machine/odroid-c1.conf
+++ b/conf/machine/odroid-c1.conf
@@ -6,6 +6,7 @@ TARGET_ARCH = "arm"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
         u-boot-ini \
+        kernel-image \
         kernel-devicetree \
         "
 


### PR DESCRIPTION
I wrongly removed kernel-image in commit
91fbd72037956d883751051c22ff59112b490cc7. It was working for me
previously, but kernel image is missing in clean build with
core-image-minimal.

Signed-off-by: Tomas Novotny tomas.novotny@tbs-biometrics.com
