### PR TITLE
odroid-ux3 kernel: remove machine specific assignment of COMPATIBLE_M

### DIFF
--- a/recipes-kernel/linux/linux-odroid_3.10.bb
+++ b/recipes-kernel/linux/linux-odroid_3.10.bb
@@ -16,4 +16,4 @@ LINUX_VERSION_EXTENSION_odroid-ux3 ?= "odroid-ux3"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
-COMPATIBLE_MACHINE_odroid-ux3 = "odroid-ux3"
+COMPATIBLE_MACHINE = "odroid-ux3"


### PR DESCRIPTION
If I understand correctly, COMPATIBLE_MACHINE shouldn't be machine specific. With that fix I'm able to build odroid-c1 image again.
