### PR TITLE
image_types_odroid.bbclass: add DEPENDS for sync

### DIFF
--- a/classes/image_types_odroid.bbclass
+++ b/classes/image_types_odroid.bbclass
@@ -41,6 +41,7 @@ BOOT_SPACE ?= "131000"
 IMAGE_DEPENDS_sdcard = "parted-native:do_populate_sysroot \
                         dosfstools-native:do_populate_sysroot \
                         mtools-native:do_populate_sysroot \
+                        coreutils-native:do_populate_sysroot \
                         virtual/kernel:do_deploy \
                         ${@d.getVar('IMAGE_BOOTLOADER', True) and d.getVar('IMAGE_BOOTLOADER', True) + ':do_deploy' or ''}"
 


### PR DESCRIPTION
This class is trying to invoke "sync", which it can't find (probably a victim
of RSS).

	| /path/build/tmp-glibc/work/odroid_c2-oe-linux/core-image-minimal/1.0-r0/temp/run.do_image_sdcard.14272: line 171: sync: command not found
	| WARNING: /path/build/tmp-glibc/work/odroid_c2-oe-linux/core-image-minimal/1.0-r0/temp/run.do_image_sdcard.14272:1 exit 127 from 'sync'

Signed-off-by: Trevor Woerner <twoerner@gmail.com>