### PR TITLE
machine/include/odroid-default-settings: Use += to add values to IMAGE_FSTYPES

### DIFF
--- a/conf/machine/include/odroid-default-settings.inc
+++ b/conf/machine/include/odroid-default-settings.inc
@@ -40,5 +40,5 @@ MACHINE_EXTRA_RRECOMMENDS += " kernel-modules kernel-devicetree"
 
 EXTRA_IMAGEDEPENDS += "u-boot"
 
-IMAGE_FSTYPES_append = " ext4 sdcard"
+IMAGE_FSTYPES += " ext4 sdcard"
 IMAGE_CLASSES += "image_types_odroid"


### PR DESCRIPTION
Using _append will add ext4 and sdcard to IMAGE_FSTYPES, but if we
wic to generate image, using IMAGE_FSTYPES = "wic", the final result
will be one .wic image and other .sdcard image.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>