### PR TITLE
odroid-c2-hardkernel.conf: Remove duplicates

### DIFF
--- a/conf/machine/odroid-c2-hardkernel.conf
+++ b/conf/machine/odroid-c2-hardkernel.conf
@@ -6,13 +6,14 @@
 require conf/machine/odroid-c2.conf
 
 SERIAL_CONSOLE = "115200 ttyS0"
-UBOOT_CONSOLE = "console=ttyS0,115200"
 
-KERNEL_DEVICETREE_FN_odroid-c2-hardkernel = "meson64_odroidc2.dtb"
-KERNEL_DEVICETREE_odroid-c2-hardkernel = "meson64_odroidc2.dtb"
+KERNEL_DEVICETREE_FN = "meson64_odroidc2.dtb"
+KERNEL_DEVICETREE = "meson64_odroidc2.dtb"
 
-UBOOT_KERNEL_NAME = "Image"
 UBOOT_SCRIPT = "boot.ini"
+UBOOT_ENV_SUFFIX = "ini"
+UBOOT_ENV_CONFIG = "${B}/${UBOOT_ENV}.${UBOOT_ENV_SUFFIX}"
+UBOOT_CONSOLE = "console=ttyS0,115200"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-hardkernel"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-hardkernel"
@@ -21,25 +22,3 @@ PREFERRED_VERSION_linux-libc-headers = "3.16%"
 PREFERRED_VERSION_linux-hardkernel = "3.16%"
 
 MACHINEOVERRIDES .= ":odroid-c2"
-
-UBOOT_ENV_SUFFIX = "ini"
-UBOOT_ENV_CONFIG = "${B}/${UBOOT_ENV}.${UBOOT_ENV_SUFFIX}"
-
-MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "kernel-image kernel-devicetree"
-
-IMAGE_FSTYPES_append = " wic.gz"
-
-# Do not update fstab file when using wic images
-WIC_CREATE_EXTRA_ARGS ?= "--no-fstab-update"
-
-IMAGE_BOOT_FILES = ""
-
-# wic default support
-WKS_FILE_DEPENDS ?= " \
-    e2fsprogs-native \
-    bmap-tools-native \
-"
-
-WKS_FILE ?= "odroid-c2.wks"
-
-IMAGE_BOOT_FILES = "boot.ini"


### PR DESCRIPTION
This file inherits odroid-c2 config and there
is lot of duplication that can be removed

Signed-off-by: Khem Raj <raj.khem@gmail.com>