### PR TITLE
mali: Ignore file-rdeps for musl

### DIFF
--- a/recipes-graphics/mali/mali.inc
+++ b/recipes-graphics/mali/mali.inc
@@ -9,6 +9,7 @@ PROVIDES += "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'virtual/egl virt
 PROVIDES += "${@bb.utils.contains("DISTRO_FEATURES", "wayland", " virtual/libwayland-egl", " ", d)}"
 
 INSANE_SKIP_${PN} = "ldflags dev-so"
+INSANE_SKIP_${PN}_append_libc-musl = " file-rdeps"
 
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_PACKAGE_STRIP = "1"


### PR DESCRIPTION
Prebuilt libraries are built against glibc so they have different
SONAMES encoded in them. However for musl we do provide symlinks for
them but they are not individual libraries like glibc

Signed-off-by: Khem Raj <raj.khem@gmail.com>