### PR TITLE
linux-libc-headers_3.16.bb: Define own LIC_FILES_CHKSUM

### DIFF
--- a/recipes-kernel/linux-libc-headers/linux-libc-headers_3.16.bb
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers_3.16.bb
@@ -1,5 +1,7 @@
 require recipes-kernel/linux-libc-headers/linux-libc-headers.inc
 
+LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
+
 do_install_armmultilib () {
         oe_multilib_header asm/auxvec.h asm/bitsperlong.h asm/byteorder.h asm/fcntl.h asm/hwcap.h asm/ioctls.h asm/kvm.h asm/mman.h asm/param.h
         oe_multilib_header asm/posix_types.h asm/ptrace.h  asm/setup.h  asm/sigcontext.h asm/siginfo.h asm/signal.h asm/stat.h  asm/statfs.h asm/swab.h  asm/types.h asm/unistd.h


### PR DESCRIPTION
OE-Core checksums changed when it got kernel headers moving to 4.18
we still need to have old checksums for 3.16 headers

Signed-off-by: Khem Raj <raj.khem@gmail.com>