### PR TITLE
odroid-c2-hardkernel.conf: Mark empty KERNEL_EXTRA_FEATURES, unbreak …

### DIFF
--- a/conf/machine/odroid-c2-hardkernel.conf
+++ b/conf/machine/odroid-c2-hardkernel.conf
@@ -9,6 +9,7 @@ SERIAL_CONSOLE = "115200 ttyS0"
 
 KERNEL_DEVICETREE_FN = "meson64_odroidc2.dtb"
 KERNEL_DEVICETREE = "meson64_odroidc2.dtb"
+KERNEL_EXTRA_FEATURES = ""
 
 UBOOT_SCRIPT = "boot.ini"
 UBOOT_ENV_SUFFIX = "ini"


### PR DESCRIPTION
…odroid-c3-hk machine

hardkernel vendor kernel does not use yocto tooling
to manage configs via kmeta

Signed-off-by: Khem Raj <raj.khem@gmail.com>