### PR TITLE
wayland: Keep wayland-egl.pc when using mali

### DIFF
--- a/meta-odroid-extras/recipes-graphics/wayland/wayland_%.bbappend
+++ b/meta-odroid-extras/recipes-graphics/wayland/wayland_%.bbappend
@@ -4,6 +4,5 @@ PROVIDES_remove  = "${@bb.utils.contains('MACHINE_FEATURES', 'mali', 'virtual/li
 do_install_append_odroid () {
     if [ -n "${@bb.utils.contains('MACHINE_FEATURES', 'mali', 'mali', '', d)}" ]; then
         rm -f ${D}/${libdir}/libwayland-egl.so*
-        rm -f ${D}/${libdir}/pkgconfig/wayland-egl.pc
     fi
 }


### PR DESCRIPTION
I am trying to build odroid-x11-image on thud but I was getting an error on gtk+3  "No package 'wayland-egl' found"

Setup:

* I am on thud version.
* This is my local.conf:

```
MACHINE ??= "odroid-xu4"
DISTRO ?= "poky"
PACKAGE_CLASSES ?= "package_ipk"
USER_CLASSES ?= "buildstats image-mklibs image-prelink"
IMAGE_INSTALL_append = " opencv boost"
EXTRA_IMAGE_FEATURES ?= "debug-tweaks x11-base tools-debug splash ssh-server-dropbear package-management"
```

* bblayers:
```
BBLAYERS ?= " \
  poky/meta \
  poky/meta-poky \
  poky/meta-yocto-bsp \
  meta-openembedded/meta-oe \
  meta-openembedded/meta-networking \
  meta-openembedded/meta-filesystems \
  meta-python \
  meta-odroid \
  meta-odroid/meta-odroid-extras \
  "
```