### PR TITLE
odroid-arm-defaults: fixup removed classes

### DIFF
--- a/conf/machine/include/odroid-arm-defaults.inc
+++ b/conf/machine/include/odroid-arm-defaults.inc
@@ -41,4 +41,4 @@ EXTRA_IMAGEDEPENDS_append = " u-boot secure-odroid"
 EXTRA_IMAGEDEPENDS_append = " ${@bb.utils.contains("DISTRO_FEATURES", "x11", " odroid-edid", " ", d)}"
 IMAGE_INSTALL_append = " kernel-devicetree"
 
-IMAGE_CLASSES += "image_types_nfs image_types_odroid netboot"
+IMAGE_CLASSES += "image_types_odroid"


### PR DESCRIPTION
In commit 33f1c8c8d5c347bad925a0c9adbe3ed3841a9a16 these classes were moved to
their own layer leaving "Could not inherit file classesnetboot.bbclass" and
classes/image_types_nfs.bbclass".

Signed-off-by: Trevor Woerner <twoerner@gmail.com>