### PR TITLE
mali: Let native/nativesdk versions come for mesa-native/mesa-nativesdk

### DIFF
--- a/recipes-graphics/mali/mali-450_r7p0.bb
+++ b/recipes-graphics/mali/mali-450_r7p0.bb
@@ -55,10 +55,4 @@ do_install () {
 RDEPENDS_${PN} += "kernel-module-mali-utgard libffi"
 RDEPENDS_${PN} += "${@bb.utils.contains("DISTRO_FEATURES", "wayland", "wayland", " ", d)}"
 RDEPENDS_${PN}_remove_odroid-c2-hardkernel = "kernel-module-mali-utgard"
-COMPATIBLE_MACHINE_class-target = "odroid-c2"
-
-INHIBIT_SYSROOT_STRIP = "1"
- 
-RDEPENDS_${PN}_class-native = ""
-  
-BBCLASSEXTEND = "native nativesdk"
+COMPATIBLE_MACHINE = "odroid-c2"

--- a/recipes-graphics/mali/mali-t62x_r12p0_00rel0.bb
+++ b/recipes-graphics/mali/mali-t62x_r12p0_00rel0.bb
@@ -42,13 +42,9 @@ do_install () {
 		ln -sf libwayland-egl.so.1 ${D}/${libdir}/libwayland-egl.so
 	fi
 }
-INHIBIT_SYSROOT_STRIP = "1"
-
 FILES_${PN} = "${libdir}/lib*.so*"
 
 RDEPENDS_${PN} += "kernel-module-mali-t62x"
-RDEPENDS_${PN}_class-native = ""
  
-COMPATIBLE_MACHINE_class-target = "odroid-xu3|odroid-xu3-lite|odroid-xu4"
-BBCLASSEXTEND = "native nativesdk"
+COMPATIBLE_MACHINE = "odroid-xu3|odroid-xu3-lite|odroid-xu4"
 


### PR DESCRIPTION
This avoids conflicts like (libepoxy-native)
ERROR: The file /usr/include/KHR/khrplatform.h is installed by both mali-450-native and mesa-native, aborting

Signed-off-by: Khem Raj <raj.khem@gmail.com>