### PR TITLE
odroid-c4-hardkernel: Bump loadaddr for kernel

### DIFF
--- a/recipes-bsp/u-boot/u-boot-hardkernel/odroid-c4-hardkernel/boot.ini
+++ b/recipes-bsp/u-boot/u-boot-hardkernel/odroid-c4-hardkernel/boot.ini
@@ -20,7 +20,7 @@ setenv dtbo_addr_r "0x11000000"
 setenv k_addr "0x1100000"
 #setenv loadaddr "0x1B00000"
 # For kernel+initramfs
-setenv loadaddr "0x2300000"
+setenv loadaddr "0x2800000"
 
 load mmc ${devno}:1 ${loadaddr} config.ini \
     && ini generic ${loadaddr}


### PR DESCRIPTION
This is to accomodate larger kernel+initramfs ( > 20M)

Signed-off-by: Khem Raj <raj.khem@gmail.com>