### PR TITLE
odroid-c4-hardkernel.conf: Do not install kernel and devicetree in ro…

### DIFF
--- a/conf/machine/odroid-c4-hardkernel.conf
+++ b/conf/machine/odroid-c4-hardkernel.conf
@@ -33,8 +33,10 @@ KERNEL_DEVICETREE_append = "\
 "
 
 # This goes into /boot dir of rootfs
-IMAGE_INSTALL_remove = "kernel-image-image"
-#IMAGE_INSTALL_append = " kernel-image-image.gz"
+IMAGE_INSTALL_remove = "kernel-image-${KERNEL_IMAGETYPE} \
+                        kernel-image-image kernel-image \
+                        kernel-devicetree \
+                        "
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-hardkernel"
 PREFERRED_VERSION_linux-hardkernel ?= "4.9%"

--- a/recipes-core/packagegroups/packagegroup-core-tools-profile.bbappend
+++ b/recipes-core/packagegroups/packagegroup-core-tools-profile.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+# perf fails to build with 4.9 kernel
+PERF_odroid-c4-hardkernel = ""


### PR DESCRIPTION
…otfs

this is a redundant copy, actual used copies are in boot parition of wic
already

Signed-off-by: Khem Raj <raj.khem@gmail.com>