### PR TITLE
odroid-c4-hardkernel.conf: Do not pin gcc versions

### DIFF
--- a/conf/machine/odroid-c4-hardkernel.conf
+++ b/conf/machine/odroid-c4-hardkernel.conf
@@ -41,9 +41,6 @@ IMAGE_INSTALL_remove = "\
                         kernel-devicetree \
                         "
 
-PREFERRED_VERSION_gcc = "8.3"
-GCCVERSION = "arm-8.3"
-
 PREFERRED_PROVIDER_virtual/kernel = "linux-hardkernel"
 PREFERRED_VERSION_linux-hardkernel ?= "4.9%"
 


### PR DESCRIPTION
8.3 is gone and we are able to use gcc 10 to build this device rootfs

Signed-off-by: Khem Raj <raj.khem@gmail.com>