### PR TITLE
odroid-c4-hardkernel: Switch back to cortexa55 defaulttune

### DIFF
--- a/conf/machine/odroid-c4-hardkernel.conf
+++ b/conf/machine/odroid-c4-hardkernel.conf
@@ -5,9 +5,6 @@
 
 require conf/machine/odroid-c4.conf
 
-#This tune is needed if using the arm toolchain
-DEFAULTTUNE = "armv8a-crc-crypto"
-
 KERNEL_DEVICETREE_append = "\
     amlogic/overlays/odroidc4/spi0.dtbo \
     amlogic/overlays/odroidc4/i2c0.dtbo \


### PR DESCRIPTION
meta-arm has since dropped arm-8.3 toolchain and we have also removed
dependency on it already

Signed-off-by: Khem Raj <raj.khem@gmail.com>