### PR TITLE
packagegroup-qt5: Mark it as TUNE_PKGARCH

### DIFF
--- a/meta-odroid-extras/dynamic-layers/qt5-layer/recipes/packagegroups/packagegroup-qt5.bb
+++ b/meta-odroid-extras/dynamic-layers/qt5-layer/recipes/packagegroups/packagegroup-qt5.bb
@@ -2,6 +2,8 @@ DESCRIPTION = "QT5 base package group"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
+PACKAGE_ARCH = "${TUNE_PKGARCH}"
+
 inherit packagegroup
 
 RDEPENDS:${PN} = " \


### PR DESCRIPTION
Fixes
ERROR: packagegroup-qt5-1.0-r0 do_package_write_ipk: An allarch packagegroup shouldn't depend on packages which are dynamically renamed (qtsensors-dev to libqt5sensors-dev)
ERROR: packagegroup-qt5-1.0-r0 do_package_write_ipk: An allarch packagegroup shouldn't depend on packages which are dynamically renamed (qtsvg-dev to libqt5svg-dev)
ERROR: packagegroup-qt5-1.0-r0 do_package_write_ipk: An allarch packagegroup shouldn't depend on packages which are dynamically renamed (qtsensors to libqt5sensors5)
ERROR: packagegroup-qt5-1.0-r0 do_package_write_ipk: An allarch packagegroup shouldn't depend on packages which are dynamically renamed (qtsvg to libqt5svg5)
ERROR: packagegroup-qt5-1.0-r0 do_package_write_ipk: An allarch packagegroup shouldn't depend on packages which are dynamically renamed (qtsvg-plugins to libqt5svg-plugins)

Signed-off-by: Khem Raj <raj.khem@gmail.com>