### PR TITLE
linux-hardkernel_5.10.bb: Add protocol= explicitly to github SRC_URI

### DIFF
--- a/recipes-kernel/linux/linux-hardkernel_5.10.bb
+++ b/recipes-kernel/linux/linux-hardkernel_5.10.bb
@@ -8,7 +8,7 @@ LINUX_VERSION ?= "5.10.27"
 EXTRA_OEMAKE:append = " KBUILD=${B}"
 require linux-hardkernel.inc
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
-SRC_URI = "git://github.com/tobetter/linux.git;branch=${KBRANCH} \
+SRC_URI = "git://github.com/tobetter/linux.git;branch=${KBRANCH};protocol=https \
 "
 
 SRC_URI:append = " file://defconfig"


### PR DESCRIPTION
Fixes
WARNING: /mnt/b/yoe/master/sources/meta-odroid/recipes-kernel/linux/linux-hardkernel_5.10.bb: URL: git://github.com/tobetter/linux.git;branch=odroid-5.10.y uses git protocol which is no longer supported by github. Please change to ;protocol=http s in the url.

Signed-off-by: Khem Raj <raj.khem@gmail.com>