### PR TITLE
odroid: clean up machine config files

### DIFF
--- a/conf/machine/include/odroid-arm-defaults.inc
+++ b/conf/machine/include/odroid-arm-defaults.inc
@@ -48,7 +48,6 @@ BOOT_PREFIX ?= "boot/"
 
 UBOOT_EXTRA_ENV ?= ""
 UBOOT_FILE_TITLE ?= "#"
-BOOT_PREFIX ?= ""
 UBOOT_VIDEO ?= "${@bb.utils.contains("DISTRO_FEATURES", "x11", "drm.edid_firmware=edid/1024x768.bin", " ", d)}"
 UBOOT_XTRA_CMDLINE ?=  "${@bb.utils.contains('DISTRO_FEATURES', 'TS_vu7+', 'usbhid.quirks=0x16B4:0x0703:0x00000040 ', '', d)}"
 
@@ -63,5 +62,3 @@ EXTRA_IMAGEDEPENDS:append = " ${@bb.utils.contains("DISTRO_FEATURES", "x11", " o
 
 IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
 IMAGE_CLASSES += "image_types_odroid"
-
-

--- a/conf/machine/odroid-c2.conf
+++ b/conf/machine/odroid-c2.conf
@@ -9,7 +9,6 @@ require conf/machine/include/amlogic-meson64.inc
 DEFAULTTUNE ?= "cortexa53-crypto"
 require conf/machine/include/odroid-arm-defaults.inc
 
-KERNEL_DEVICETREE_FN = "meson-gxbb-odroidc2.dtb"
 KERNEL_DEVICETREE = "amlogic/meson-gxbb-odroidc2.dtb"
 
 #specify u-boot parameters

--- a/conf/machine/odroid-c4-hardkernel.conf
+++ b/conf/machine/odroid-c4-hardkernel.conf
@@ -6,7 +6,6 @@
 require conf/machine/odroid-c4.conf
 require conf/machine/include/hardkernel.inc
 
-KERNEL_DEVICETREE_FN = "meson64_odroidc4.dtb"
 KERNEL_DEVICETREE = "amlogic/meson64_odroidc4.dtb"
 UBOOT_BINARY = "u-boot.bin"
 

--- a/conf/machine/odroid-c4.conf
+++ b/conf/machine/odroid-c4.conf
@@ -9,7 +9,6 @@ require conf/machine/include/odroid-arm-defaults.inc
 
 SERIAL_CONSOLE = "115200 ttyS0"
 
-KERNEL_DEVICETREE_FN = "meson-sm1-odroid-c4.dtb"
 KERNEL_DEVICETREE = "amlogic/meson-sm1-odroid-c4.dtb"
 
 UBOOT_BINARY = "u-boot.bin.sd.bin"

--- a/conf/machine/odroid-hc4-hardkernel.conf
+++ b/conf/machine/odroid-hc4-hardkernel.conf
@@ -26,5 +26,4 @@
 
 require conf/machine/odroid-c4-hardkernel.conf
 
-KERNEL_DEVICETREE_FN = "meson64_odroidhc4.dtb"
 KERNEL_DEVICETREE = "amlogic/meson64_odroidhc4.dtb"

--- a/conf/machine/odroid-hc4.conf
+++ b/conf/machine/odroid-hc4.conf
@@ -28,7 +28,6 @@ require conf/machine/include/odroid-arm-defaults.inc
 
 SERIAL_CONSOLE = "115200 ttyS0"
 
-KERNEL_DEVICETREE_FN = "meson-sm1-odroid-hc4.dtb"
 KERNEL_DEVICETREE = "amlogic/meson-sm1-odroid-hc4.dtb"
 
 UBOOT_BINARY = "u-boot.bin.sd.bin"

--- a/conf/machine/odroid-n2-hardkernel.conf
+++ b/conf/machine/odroid-n2-hardkernel.conf
@@ -10,7 +10,6 @@ DEFAULTTUNE ?= "cortexa73-cortexa53-crypto"
 require conf/machine/include/odroid-arm-defaults.inc
 require conf/machine/include/hardkernel.inc
 
-KERNEL_DEVICETREE_FN = "meson64_odroidn2.dtb"
 KERNEL_DEVICETREE = "amlogic/meson64_odroidn2.dtb"
 KERNEL_EXTRA_FEATURES = ""
 

--- a/conf/machine/odroid-n2.conf
+++ b/conf/machine/odroid-n2.conf
@@ -9,7 +9,6 @@ require conf/machine/include/amlogic-meson64.inc
 DEFAULTTUNE ?= "cortexa73-cortexa53-crypto"
 require conf/machine/include/odroid-arm-defaults.inc
 
-KERNEL_DEVICETREE_FN = "meson-g12b-odroid-n2.dtb"
 KERNEL_DEVICETREE = "amlogic/meson-g12b-odroid-n2.dtb"
 KERNEL_EXTRA_FEATURES = ""
 


### PR DESCRIPTION
Remove unused and duplicated variables, clean whitespace.

Signed-off-by: Renato Caldas <renato@calgera.com>