### PR TITLE
odroid-xu: fix QA Issue: Malformed Upstream-Status in patch

### DIFF
--- a/recipes-bsp/u-boot/u-boot/0001-odroid-xu3-defconfig-disable-CONFIG_BOARD_LATE_INIT.patch
+++ b/recipes-bsp/u-boot/u-boot/0001-odroid-xu3-defconfig-disable-CONFIG_BOARD_LATE_INIT.patch
@@ -7,7 +7,7 @@ the 2023 now wont boot unless that config option is off.
 
 cros-ec communications failure -96
 
-Upstream-Status: Inappropriate[configuration]
+Upstream-Status: Inappropriate [configuration]
 
 Signed-off-by: Armin Kuster <akuster808@gmail.com>
 ---
@@ -26,6 +26,5 @@ index 7593d1fbcd..1e57fa3cee 100644
  CONFIG_MISC_INIT_R=y
  CONFIG_SYS_PBSIZE=1024
  CONFIG_CMD_THOR_DOWNLOAD=y
--- 
+--
 2.25.1
-


### PR DESCRIPTION
There was a space missing between `Inappropriate` and `[configuration]`.