### PR TITLE
recipes: Add Upstream-Status tags

### DIFF
--- a/recipes-bsp/arm-trusted-firmware/files/add_odroid_c2.patch
+++ b/recipes-bsp/arm-trusted-firmware/files/add_odroid_c2.patch
@@ -1,3 +1,7 @@
+Add bl30 and bl301 firmware image headers
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
 Index: git/include/common/firmware_image_package.h
 ===================================================================
 --- git.orig/include/common/firmware_image_package.h

--- a/recipes-bsp/u-boot-hardkernel/files/0001-ARM-asm-io.h-use-static-inline.patch
+++ b/recipes-bsp/u-boot-hardkernel/files/0001-ARM-asm-io.h-use-static-inline.patch
@@ -3,6 +3,7 @@ From: Armin Kuster <akuster808@gmail.com>
 Date: Sat, 7 May 2016 12:17:37 -0700
 Subject: [PATCH] ARM:asm:io.h use static inline
 
+Upstream-Status: Pending
 Signed-off-by: Armin Kuster <akuster808@gmail.com>
 ---
  arch/arm/include/asm/io.h | 12 ++++++------

--- a/recipes-bsp/u-boot-hardkernel/files/0001-board.c-fix-inline-issue.patch
+++ b/recipes-bsp/u-boot-hardkernel/files/0001-board.c-fix-inline-issue.patch
@@ -3,6 +3,7 @@ From: Armin Kuster <akuster808@gmail.com>
 Date: Sat, 7 May 2016 12:27:47 -0700
 Subject: [PATCH] board.c: fix inline issue
 
+Upstream-Status: Pending
 Signed-off-by: Armin Kuster <akuster808@gmail.com>
 ---
  arch/arm/lib/board.c | 18 +++++++++---------

--- a/recipes-bsp/u-boot-hardkernel/files/0001-compile-add-gcc5.patch
+++ b/recipes-bsp/u-boot-hardkernel/files/0001-compile-add-gcc5.patch
@@ -3,6 +3,7 @@ From: Armin Kuster <akuster808@gmail.com>
 Date: Sat, 7 May 2016 12:21:43 -0700
 Subject: [PATCH] compile: add gcc5
 
+Upstream-Status: Pending
 Signed-off-by: Armin Kuster <akuster808@gmail.com>
 ---
  include/linux/compiler-gcc5.h | 65 +++++++++++++++++++++++++++++++++++++++++++

--- a/recipes-bsp/u-boot-hardkernel/files/0001-compiler_gcc-do-not-redefine-__gnu_attributes.patch
+++ b/recipes-bsp/u-boot-hardkernel/files/0001-compiler_gcc-do-not-redefine-__gnu_attributes.patch
@@ -13,6 +13,7 @@ these macros to suppress these warnings.
 This patch ignores the checkpatch warning:
 WARNING: __packed is preferred over __attribute__((packed))
 
+Upstream-Status: Pending
 Signed-off-by: Jeroen Hofstee <jeroen@myspectrum.nl>
 ---
  include/linux/compiler-gcc.h  | 12 +++++++++---

--- a/recipes-bsp/u-boot-hardkernel/files/0001-gcc-7-fix.patch
+++ b/recipes-bsp/u-boot-hardkernel/files/0001-gcc-7-fix.patch
@@ -3,6 +3,7 @@ From: Armin Kuster <akuster@mvista.com>
 Date: Sat, 23 Sep 2017 11:28:13 -0700
 Subject: [PATCH] gcc 7 fix
 
+Upstream-Status: Pending
 Signed-off-by: Armin Kuster <akuster@mvista.com>
 ---
  include/linux/compiler-gcc.h | 266 ++++++++++++++++++++++++++++++++++++------

--- a/recipes-bsp/u-boot-hardkernel/files/0001-main-fix-inline-issue.patch
+++ b/recipes-bsp/u-boot-hardkernel/files/0001-main-fix-inline-issue.patch
@@ -3,6 +3,7 @@ From: Armin Kuster <akuster808@gmail.com>
 Date: Sat, 7 May 2016 12:30:29 -0700
 Subject: [PATCH] main: fix inline issue
 
+Upstream-Status: Pending
 Signed-off-by: Armin Kuster <akuster808@gmail.com>
 ---
  common/main.c | 2 +-

--- a/recipes-bsp/u-boot-hardkernel/files/0001-usb-use-define-not-func.patch
+++ b/recipes-bsp/u-boot-hardkernel/files/0001-usb-use-define-not-func.patch
@@ -3,6 +3,7 @@ From: Armin Kuster <akuster808@gmail.com>
 Date: Sat, 7 May 2016 12:47:12 -0700
 Subject: [PATCH] usb: use define not func
 
+Upstream-Status: Pending
 Signed-off-by: Armin Kuster <akuster808@gmail.com>
 ---
  common/usb.c  | 4 ++--

--- a/recipes-bsp/u-boot-hardkernel/files/0002-added-hardfp-support.patch
+++ b/recipes-bsp/u-boot-hardkernel/files/0002-added-hardfp-support.patch
@@ -1,3 +1,8 @@
+Add hardfp to compile options
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
 Index: git/arch/arm/cpu/aml_meson/config.mk
 ===================================================================
 --- git.orig/arch/arm/cpu/aml_meson/config.mk

--- a/recipes-bsp/u-boot-hardkernel/files/0003-use-lldiv-for-64-bit-division.patch
+++ b/recipes-bsp/u-boot-hardkernel/files/0003-use-lldiv-for-64-bit-division.patch
@@ -8,6 +8,7 @@ Otherwise u-boot will crash with
 
 The original Patch was from Ilya Yanok yanok@emcraft.com
 
+Upstream-Status: Pending
 Signed-off-by: Christian Ege <k4230r6@gmail.com>
 ---
  drivers/mmc/aml_sd_mmc.c |    3 ++-

--- a/recipes-bsp/u-boot-hardkernel/files/m8_osd_hw_build_fix.patch
+++ b/recipes-bsp/u-boot-hardkernel/files/m8_osd_hw_build_fix.patch
@@ -1,3 +1,10 @@
+Fix osd build
+
+Control osd_vf_prov definition by CONFIG_AM_VIDEO
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+
 Index: git/drivers/video/osd/m8_osd_hw.c
 ===================================================================
 --- git.orig/drivers/video/osd/m8_osd_hw.c

--- a/recipes-kernel/linux/linux-hardkernel-4.9/0001-Disable-misleading-indentation-warning.patch
+++ b/recipes-kernel/linux/linux-hardkernel-4.9/0001-Disable-misleading-indentation-warning.patch
@@ -7,6 +7,7 @@ GCC 11 finds some of these warnings anew in amlogic drivers
 ideally the warnings should be fixed but for build purpose
 ignoring it as error is ok
 
+Upstream-Status: Pending
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 ---
  Makefile                           | 1 +

--- a/recipes-kernel/linux/linux-yocto-6.1/odroid/0001-arm64-dts-meson-Enable-active-coling-using-gpio-fan-.patch
+++ b/recipes-kernel/linux/linux-yocto-6.1/odroid/0001-arm64-dts-meson-Enable-active-coling-using-gpio-fan-.patch
@@ -8,6 +8,7 @@ Odroid N2/N2+ support active cooling via gpio-fan controller.
 Add fan controls and tip point for cpu and ddr thermal sensor
 on this boards.
 
+Upstream-Status: Backport [https://lore.kernel.org/r/20221021050906.1158-1-linux.amoon@gmail.com]
 Signed-off-by: Anand Moon <linux.amoon@gmail.com>
 Link: https://lore.kernel.org/r/20221021050906.1158-1-linux.amoon@gmail.com
 Signed-off-by: Neil Armstrong <neil.armstrong@linaro.org>

--- a/recipes-kernel/linux/linux-yocto-6.1/odroid/0001-exynos5422-odroidhc1.dts-fix-booting-from-mmc.patch
+++ b/recipes-kernel/linux/linux-yocto-6.1/odroid/0001-exynos5422-odroidhc1.dts-fix-booting-from-mmc.patch
@@ -3,6 +3,7 @@ From: Armin Kuster <akuster@mvista.com>
 Date: Fri, 23 Mar 2018 09:02:44 -0700
 Subject: [PATCH] exynos5422-odroidhc1.dts: fix booting from mmc
 
+Upstream-Status: Pending
 Signed-off-by: Armin Kuster <akuster@mvista.com>
 ---
  arch/arm/boot/dts/exynos5422-odroidhc1.dts | 37 ++++++++++++++++++++++++++++++

--- a/recipes-kernel/linux/linux-yocto-6.1/odroid/0002-arm64-dts-meson-g12b-move-common-node-into-new-odroi.patch
+++ b/recipes-kernel/linux/linux-yocto-6.1/odroid/0002-arm64-dts-meson-g12b-move-common-node-into-new-odroi.patch
@@ -9,6 +9,7 @@ without some on-board peripherals (Ethernet, RTC, Hub, Jack),
 move the common nodes into a new meson-g12b-odroid.dtsi which will
 will be the common dtsi for all the Odroid-N2 derived boards.
 
+Upstream-Status: Pending
 Link: https://lore.kernel.org/r/20230122-topic-odroid-n2l-upstream-initial-v2-2-8d3fea6d403d@linaro.org
 Signed-off-by: Neil Armstrong <neil.armstrong@linaro.org>
 (cherry picked from commit 379ae64609c7a3301b60483eb65bd8bc78f76328)

--- a/recipes-kernel/linux/linux-yocto-6.1/odroid/0003-arm64-dts-meson-g12b-odroid-Add-initial-support-for-.patch
+++ b/recipes-kernel/linux/linux-yocto-6.1/odroid/0003-arm64-dts-meson-g12b-odroid-Add-initial-support-for-.patch
@@ -17,6 +17,7 @@ are removed from ODROID-N2PLUS based on S922X SoC.
 - IR remote receiver is removed
 - MIPI DSI port is added new but not yet supported
 
+Upstream-Status: Pending
 Signed-off-by: Dongjin Kim <tobetter@gmail.com>
 Link: https://lore.kernel.org/r/20230122-topic-odroid-n2l-upstream-initial-v2-3-8d3fea6d403d@linaro.org
 Signed-off-by: Neil Armstrong <neil.armstrong@linaro.org>


### PR DESCRIPTION
Add pending as a fallback, this will keep them in scope for rework and yet match the needs for tag from latest oe-core