### PR TITLE
Cleanup uboot bbclass, take2

### DIFF
--- a/classes/uboot-boot-scr.bbclass
+++ b/classes/uboot-boot-scr.bbclass
@@ -17,8 +17,6 @@
 #
 # UBOOT_BOOTPART: default boot partition #
 #
-# UBOOT_BOOTTYPE: default mmc
-#
 # UBOOT_FILE_TITLE: u-boot script title, e.g., "UBOOT-CONFIG"
 #
 # UBOOT_EXTRA_ENV: default add extra env vars , e.g., "vout,'vga'"
@@ -39,7 +37,6 @@ UBOOT_ENV_CONFIG ?= "${WORKDIR}/${UBOOT_ENV}.cmd"
 UBOOT_LOADADDRESS ?= ""
 UBOOT_FDT_LOADADDR ?= ""
 UBOOT_BOOTARGS ?= "${console} ${root} ${video} ${extra_cmdline}"
-UBOOT_BOOTTYPE ?= "mmc"
 UBOOT_KERNEL_NAME ?= ""
 UBOOT_INITRD_NAME ?= ""
 UBOOT_INITRD_ADDR ?= "-"
@@ -158,7 +155,6 @@ python create_uboot_boot_txt() {
 
             loadcmd = localdata.getVar('UBOOT_LOAD_CMD')
 
-            boottype = localdata.getVar('UBOOT_BOOTTYPE')
             bootpart = localdata.getVar('UBOOT_BOOTPART')
 
             # initrd
@@ -193,16 +189,16 @@ python create_uboot_boot_txt() {
                 if d.getVar("UBOOT_MULTI_BOOT") == "1" :
                     for p in range(0,3):
                         for d in range(1,3):
-                            cfgfile.write("if %s %s %s:%s %s %s%s; then\n" % (loadcmd, boottype, p, d, kerneladdr, bootprefix, kernelname))
-                            cfgfile.write("    %s %s %s:%s %s %s%s\n" % (loadcmd, boottype, p, d, fdtaddr, bootprefix, fdtfile))
+                            cfgfile.write("if %s ${devtype} %s:%s %s %s%s; then\n" % (loadcmd, p, d, kerneladdr, bootprefix, kernelname))
+                            cfgfile.write("    %s ${devtype} %s:%s %s %s%s\n" % (loadcmd, p, d, fdtaddr, bootprefix, fdtfile))
                             cfgfile.write("fi\n")
 
                 else:
-                    cfgfile.write("%s %s ${devnum}:%s %s %s%s\n" % (loadcmd, boottype, bootpart, fdtaddr,bootprefix, fdtfile))
-                    cfgfile.write("%s %s ${devnum}:%s %s %s%s\n" % (loadcmd, boottype, bootpart, kerneladdr, bootprefix, kernelname))
+                    cfgfile.write("%s ${devtype} ${devnum}:%s %s %s%s\n" % (loadcmd, bootpart, fdtaddr, bootprefix, fdtfile))
+                    cfgfile.write("%s ${devtype} ${devnum}:%s %s %s%s\n" % (loadcmd, bootpart, kerneladdr, bootprefix, kernelname))
 
                 if initrd:
-                    cfgfile.write("%s %s ${devnum}:%s %s %s%s\n" % (loadcmd, boottype, bootpart, initrdaddr, bootprefix, initrdname))
+                    cfgfile.write("%s ${devtype} ${devnum}:%s %s %s%s\n" % (loadcmd, bootpart, initrdaddr, bootprefix, initrdname))
 
 
             cfgfile.write("%s %s %s %s\n" % (imgbootcmd, kerneladdr, initrdaddr, fdtaddr))

--- a/classes/uboot-boot-scr.bbclass
+++ b/classes/uboot-boot-scr.bbclass
@@ -11,7 +11,7 @@
 #
 # UBOOT_CONSOLE: default console, e.g.,  "ttyttySAC2,115200"
 #
-# UBOOT_LOAD_CMD: default partition, e.g., "load"
+# UBOOT_LOAD_CMD: default load command, e.g., "load"
 #
 # UBOOT_BOOTARGS:
 #
@@ -19,7 +19,7 @@
 #
 # UBOOT_BOOTTYPE: default mmc
 #
-# UBOOT_FILE_TITLE: default partition, e.g., "UBOOT-CONFIG"
+# UBOOT_FILE_TITLE: u-boot script title, e.g., "UBOOT-CONFIG"
 #
 # UBOOT_EXTRA_ENV: default add extra env vars , e.g., "vout,'vga'"
 #

--- a/classes/uboot-boot-scr.bbclass
+++ b/classes/uboot-boot-scr.bbclass
@@ -42,8 +42,7 @@ UBOOT_INITRD_NAME ?= ""
 UBOOT_INITRD_ADDR ?= "-"
 UBOOT_ROOT_ARGS ?= "rw rootwait"
 UBOOT_NFS_ARGS ?= ",tcp,v3,wsize=8192,rsize=8192"
-UBOOT_ROOT_mmc ?= "mmcblk1p2 ${UBOOT_ROOT_ARGS}"
-UBOOT_ROOT_nfs ?= "nfs ${UBOOT_ROOT_ARGS}"
+UBOOT_ROOT ?= "mmcblk1p2"
 
 UBOOT_CONSOLE ?= ""
 UBOOT_BOOTPART ?= "1"
@@ -67,11 +66,8 @@ UBOOT_ETHADDR ?= ""
 UBOOT_HOSTNAME ?="${MACHINE}"
 UBOOT_ROOTPATH ?= "${NFS_ROOT}${MACHINE}"
 UBOOT_USB_NET ?= "0"
-UBOOT_BOOT_TYPE ?= ""
 UBOOT_NETBOOT ?= ""
 UBOOT_BOOTPATH ?= "${MACHINE}"
-
-USING_NFS = "${@bb.utils.contains_any('UBOOT_BOOT_TYPE', 'nfs', '1', '', d)}"
 
 python create_uboot_boot_txt() {
     if d.getVar("USE_BOOTSCR") != "1":
@@ -85,12 +81,6 @@ python create_uboot_boot_txt() {
         bb.fatal('Unable to read UBOOT_ENV_CONFIG')
 
     localdata = bb.data.createCopy(d)
-
-    if localdata.getVar("USING_NFS"):
-        localdata.setVar('UBOOT_ROOT', localdata.getVar('UBOOT_ROOT_nfs'))
-    else:
-        localdata.setVar('UBOOT_ROOT', localdata.getVar('UBOOT_ROOT_mmc'))
-
 
     try:
         with open(cfile, 'w') as cfgfile:
@@ -121,7 +111,8 @@ python create_uboot_boot_txt() {
                 cfgfile.write('setenv console \"%s\" \n' % console)
 
             root = localdata.getVar('UBOOT_ROOT')
-            cfgfile.write('setenv root \"root=/dev/%s\"\n' % root)
+            rootargs = localdata.getVar('UBOOT_ROOT_ARGS')
+            cfgfile.write('setenv root \"root=/dev/%s %s\"\n' % (root, rootargs))
 
             bootargs = localdata.getVar('UBOOT_BOOTARGS')
 

--- a/classes/uboot-boot-scr.bbclass
+++ b/classes/uboot-boot-scr.bbclass
@@ -3,8 +3,6 @@
 # This provides a method to create a boot.ini or boot.scr files to help
 # configure u-boot at boot up time
 #
-# UBOOT_FDT_FILE: default device tree. e.g., "KERNEL_DEVICETREE"
-#
 # UBOOT_FDT_LOADADDR: default Device tree load address, e.g., "0x01000000"
 #
 # UBOOT_INITRD_NAME: default initrd image name, e.g., "uInitrd"
@@ -15,21 +13,17 @@
 #
 # UBOOT_LOAD_CMD: default partition, e.g., "load"
 #
-# UBOOT_BOOTARGS: 
+# UBOOT_BOOTARGS:
 #
 # UBOOT_BOOTPART: default boot partition #
-# 
+#
 # UBOOT_BOOTTYPE: default mmc
-#
-# UBOOT_ROOTDEV: default root device #
-#
-# UBOOT_ROOTPART: default root device #
 #
 # UBOOT_FILE_TITLE: default partition, e.g., "UBOOT-CONFIG"
 #
 # UBOOT_EXTRA_ENV: default add extra env vars , e.g., "vout,'vga'"
 #
-# Copyright (C) 2017, Armin Kuster <akuster808@gmail.com> 
+# Copyright (C) 2017, Armin Kuster <akuster808@gmail.com>
 # All Rights Reserved Released under the MIT license (see packages/COPYING)
 #
 inherit kernel-arch
@@ -56,8 +50,6 @@ UBOOT_ROOT_nfs ?= "nfs ${UBOOT_ROOT_ARGS}"
 
 UBOOT_CONSOLE ?= ""
 UBOOT_BOOTPART ?= "1"
-UBOOT_ROOTDEV ?= ""
-UBOOT_ROOTPART ?= "2"
 UBOOT_BOOT_CMD ?= ""
 
 UBOOT_LOAD_CMD ?= "load"
@@ -82,7 +74,7 @@ UBOOT_BOOT_TYPE ?= ""
 UBOOT_NETBOOT ?= ""
 UBOOT_BOOTPATH ?= "${MACHINE}"
 
-USING_NFS = "${@bb.utils.contains_any('UBOOT_BOOT_TYPE', 'nfs', '1', '', d)}" 
+USING_NFS = "${@bb.utils.contains_any('UBOOT_BOOT_TYPE', 'nfs', '1', '', d)}"
 
 python create_uboot_boot_txt() {
     if d.getVar("USE_BOOTSCR") != "1":
@@ -129,7 +121,7 @@ python create_uboot_boot_txt() {
 
             console = localdata.getVar('UBOOT_CONSOLE')
             if console:
-                cfgfile.write('setenv console \"%s\" \n' % console) 
+                cfgfile.write('setenv console \"%s\" \n' % console)
 
             root = localdata.getVar('UBOOT_ROOT')
             cfgfile.write('setenv root \"root=/dev/%s\"\n' % root)
@@ -174,7 +166,7 @@ python create_uboot_boot_txt() {
 
             initrd = localdata.getVar('UBOOT_INITRD_NAME')
             if initrd:
-                cfgfile.write('setenv initrdname  \"%s\"\n' % initrd) 
+                cfgfile.write('setenv initrdname  \"%s\"\n' % initrd)
 
             kerneladdr = localdata.getVar('UBOOT_LOADADDRESS')
             kernelname = localdata.getVar('UBOOT_KERNEL_NAME')
@@ -228,4 +220,3 @@ do_compile:append () {
         cp ${UBOOT_ENV_CONFIG} ${WORKDIR}/${UBOOT_ENV_BINARY}
     fi
 }
-

--- a/conf/machine/include/amlogic-meson64.inc
+++ b/conf/machine/include/amlogic-meson64.inc
@@ -13,4 +13,4 @@ UBOOT_FDT_LOADADDR ?= "0x01000000"
 UBOOT_BOOT_CMD ?= "booti"
 UBOOT_KERNEL_NAME ?= "Image"
 
-UBOOT_ROOT_mmc ?= "mmcblk0p2 ${UBOOT_ROOT_ARGS}"
+UBOOT_ROOT ?= "mmcblk0p2"

--- a/conf/machine/include/odroid-arm-defaults.inc
+++ b/conf/machine/include/odroid-arm-defaults.inc
@@ -41,8 +41,6 @@ UBOOT_LOAD_CMD ?= "ext4load"
 UBOOT_BOOT_CMD ?= "bootz"
 
 UBOOT_BOOTPART ?= "2"
-UBOOT_ROOTDEV ?= "1"
-UBOOT_ROOTPART ?= "2"
 UBOOT_BOOTTYPE ?= "mmc"
 BOOT_PREFIX ?= "boot/"
 

--- a/conf/machine/include/odroid-arm-defaults.inc
+++ b/conf/machine/include/odroid-arm-defaults.inc
@@ -41,7 +41,6 @@ UBOOT_LOAD_CMD ?= "ext4load"
 UBOOT_BOOT_CMD ?= "bootz"
 
 UBOOT_BOOTPART ?= "2"
-UBOOT_BOOTTYPE ?= "mmc"
 BOOT_PREFIX ?= "boot/"
 
 UBOOT_EXTRA_ENV ?= ""

--- a/recipes-bsp/u-boot/u-boot-hardkernel_2015.01.bb
+++ b/recipes-bsp/u-boot/u-boot-hardkernel_2015.01.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a
 
 USE_BOOTSCR = "0"
 USE_BOOTSCR:odroid-n2 = "1"
-UBOOT_ROOT_mmc = "mmcblk0p2 ${UBOOT_ROOT_ARGS}"
+UBOOT_ROOT = "mmcblk0p2"
 
 UBOOT_MACHINE:odroid-c4-hardkernel = "odroidc4_defconfig"
 UBOOT_MACHINE:odroid-n2-hardkernel = "odroidn2_defconfig"


### PR DESCRIPTION
First of all, this drops `UBOOT_BOOTTYPE` and instead lets u-boot set the correct interface via `${devtype}`. This was already being done for `${devnum}`.

Second, this drops `UBOOT_BOOT_TYPE`, which was really only being used to switch between `UBOOT_ROOT_mmc` and `UBOOT_ROOT_nfs`. The latter was simply 'nfs' by default. It's simpler just to set `UBOOT_ROOT` to the correct mmc device, and overriding it to 'nfs' when needed.

As an added bonus, this makes it a lot simpler (and cleaner) to support nvme in addition to mmc.

Finally, this cleans up some unused variables, fixes documentation, and fixes two instances where `UBOOT_ROOT_ARGS` was being written twice to the boot script.